### PR TITLE
Discarding parameters about the LUCENE.VERSION

### DIFF
--- a/src/main/java/cat/lump/ie/textprocessing/word/AnalyzerFactoryLucene.java
+++ b/src/main/java/cat/lump/ie/textprocessing/word/AnalyzerFactoryLucene.java
@@ -26,7 +26,6 @@ import org.apache.lucene.analysis.ro.RomanianAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 
 import cat.lump.aq.basics.check.CHK;
-import cat.lump.ir.lucene.LuceneInterface;
 
 /**
  * Factory that allows for getting a Lucene {@code Analyzer} and a stemmer for the 
@@ -53,48 +52,48 @@ public class AnalyzerFactoryLucene {
 		
 		switch(lang){
 		case "ar":
-			analyzer = new ArabicAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new ArabicAnalyzer();
 			break;
 		case "bg":
-			analyzer = new BulgarianAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new BulgarianAnalyzer();
 			break;
 		case "ca":
-			analyzer = new CatalanAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new CatalanAnalyzer();
 			break;
 		case "cs":
-			analyzer = new CzechAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new CzechAnalyzer();
 			break;
 		case "de":
-			analyzer = new GermanAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new GermanAnalyzer();
 			break;
 		case "el":
-			analyzer = new GreekAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new GreekAnalyzer();
 			break;
 		case "en":
-			analyzer = new StandardAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new StandardAnalyzer();
 			break;
 		case "es":
-			analyzer = new SpanishAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new SpanishAnalyzer();
 			break;
 		case "eu":
-			analyzer = new BasqueAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new BasqueAnalyzer();
 			break;
 		case "fr":
-			analyzer = new FrenchAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new FrenchAnalyzer();
 			break;
 		case "it":
-			analyzer = new ItalianAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new ItalianAnalyzer();
 			break;
 		case "oc":
-			analyzer = new CatalanAnalyzer(LuceneInterface.LUCENE_VERSION);             //TODO Solve this!
+			analyzer = new CatalanAnalyzer();             //TODO Solve this!
 			CHK.CHECK(false, "Using the Catalan stemmer for language "+
 					language.getDisplayLanguage() );
 			break;
 		case "pt":
-			analyzer = new PortugueseAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new PortugueseAnalyzer();
 			break;
 		case "ro":
-			analyzer = new RomanianAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new RomanianAnalyzer();
 			break;
 		default:
 			CHK.CHECK(false, "No Lucene Analyzer is available for language "+
@@ -135,7 +134,7 @@ public class AnalyzerFactoryLucene {
 		case "de":
 			break;
 		case "el":
-			ts = new GreekLowerCaseFilter(LuceneInterface.LUCENE_VERSION, ts);
+			ts = new GreekLowerCaseFilter(ts);
 			ts = new GreekStemFilter(ts);
 			break;
 		case "en":

--- a/src/main/java/cat/lump/ir/lucene/LuceneInterface.java
+++ b/src/main/java/cat/lump/ir/lucene/LuceneInterface.java
@@ -17,7 +17,7 @@ import cat.lump.aq.basics.log.LumpLogger;
  */
 public abstract class LuceneInterface {	
 
-	public static final Version LUCENE_VERSION = Version.LUCENE_35;
+	public static final Version LUCENE_VERSION = Version.LATEST;
 	
 	/**Directory where the Lucene index has to be stored*/
 	protected final String indexDir;

--- a/src/main/java/cat/lump/ir/lucene/engine/AnalyzerFactory.java
+++ b/src/main/java/cat/lump/ir/lucene/engine/AnalyzerFactory.java
@@ -57,61 +57,61 @@ public class AnalyzerFactory {
 		
 		switch(lang){
 		case "ar":
-			analyzer = new ArabicAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new ArabicAnalyzer();
 			break;
 		case "bg":
-			analyzer = new BulgarianAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new BulgarianAnalyzer();
 			break;
 		case "ca":
-			analyzer = new CatalanAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new CatalanAnalyzer();
 			break;
 		case "cs":
-			analyzer = new CzechAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new CzechAnalyzer();
 			break;
 		case "de":
-			analyzer = new GermanAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new GermanAnalyzer();
 			break;
 		case "el":
-			analyzer = new GreekAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new GreekAnalyzer();
 			break;
 		case "en":
-			analyzer = new StandardAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new StandardAnalyzer();
 			break;
 		case "es":
-			analyzer = new SpanishAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new SpanishAnalyzer();
 			break;
 		case "eu":
-			analyzer = new BasqueAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new BasqueAnalyzer();
 			break;
 		case "fr":
-			analyzer = new FrenchAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new FrenchAnalyzer();
 			break;
 		case "hu":
-			analyzer = new HungarianAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new HungarianAnalyzer();
 			break;
 		case "it":
-			analyzer = new ItalianAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new ItalianAnalyzer();
 			break;
 		case "lt":
 			analyzer = new LithuanianAnalyzer();
 			break;	
 		case "lv":
-			analyzer = new LatvianAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new LatvianAnalyzer();
 			break;	
 		case "oc":
 			//TODO Solve this!
-			analyzer = new CatalanAnalyzer(LuceneInterface.LUCENE_VERSION);             
+			analyzer = new CatalanAnalyzer();             
 			CHK.CHECK(false, "Using the Catalan stemmer for language "+
 					language.getDisplayLanguage() );
 			break;
 		case "ro":
-			analyzer = new RomanianAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new RomanianAnalyzer();
 			break;
 		case "ru":
-			analyzer = new RussianAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new RussianAnalyzer();
 			break;
 		case "pt":
-			analyzer = new PortugueseAnalyzer(LuceneInterface.LUCENE_VERSION);
+			analyzer = new PortugueseAnalyzer();
 			break;
 		default:
 			CHK.CHECK(false, "No Lucene Analyzer is available for language "+
@@ -152,7 +152,7 @@ public class AnalyzerFactory {
 		case "de":
 			break;
 		case "el":
-			ts = new GreekLowerCaseFilter(LuceneInterface.LUCENE_VERSION, ts);
+			ts = new GreekLowerCaseFilter(ts);
 			ts = new GreekStemFilter(ts);
 			break;
 		case "en":

--- a/src/main/java/cat/lump/ir/lucene/index/LuceneIndexer.java
+++ b/src/main/java/cat/lump/ir/lucene/index/LuceneIndexer.java
@@ -103,8 +103,7 @@ public class LuceneIndexer extends LuceneInterface{
 			e.printStackTrace();
 		}
 		
-		IndexWriterConfig iwc = new IndexWriterConfig(
-				LUCENE_VERSION, 
+		IndexWriterConfig iwc = new IndexWriterConfig(				
 				analyzer 	//the analyser of the considered language
 				);
 		//We use the simple similarity model (tf-only)
@@ -177,40 +176,40 @@ public class LuceneIndexer extends LuceneInterface{
 	  Analyzer analyzer;
 		switch (lan.getLanguage()) {
 			case "ar":	
-				analyzer = new ArabicAnalyzer(LUCENE_VERSION);
+				analyzer = new ArabicAnalyzer();
 				break;			
 			case "bg":	
-				analyzer = new BulgarianAnalyzer(LUCENE_VERSION);
+				analyzer = new BulgarianAnalyzer();
 				break;
 			case "ca":	
-				analyzer = new CatalanAnalyzer(LUCENE_VERSION);
+				analyzer = new CatalanAnalyzer();
 				break;
 			case "cs":	
-				analyzer = new CzechAnalyzer(LUCENE_VERSION);
+				analyzer = new CzechAnalyzer();
 				break;				
 			case "de":	
-				analyzer = new GermanAnalyzer(LUCENE_VERSION);
+				analyzer = new GermanAnalyzer();
 				break;
 			case "el":	
-				analyzer = new GreekAnalyzer(LUCENE_VERSION);
+				analyzer = new GreekAnalyzer();
 				break;
 			case "en":	
-				analyzer = new StandardAnalyzer(LUCENE_VERSION);
+				analyzer = new StandardAnalyzer();
 				break;
 			case "es":	
-				analyzer = new SpanishAnalyzer(LUCENE_VERSION);
+				analyzer = new SpanishAnalyzer();
 				break;
 			case "et":	
-				analyzer = new EstonianAnalyzer(LUCENE_VERSION);
+				analyzer = new EstonianAnalyzer();
 				break;
 			case "eu":	
-				analyzer = new BasqueAnalyzer(LUCENE_VERSION);
+				analyzer = new BasqueAnalyzer();
 				break;
 			case "pt":	
-				analyzer = new PortugueseAnalyzer(LUCENE_VERSION);
+				analyzer = new PortugueseAnalyzer();
 				break;
 			case "fr":	
-				analyzer = new FrenchAnalyzer(LUCENE_VERSION);
+				analyzer = new FrenchAnalyzer();
 				break;
 			case "hr":	
 				analyzer = new CroatianAnalyzer();
@@ -219,10 +218,10 @@ public class LuceneIndexer extends LuceneInterface{
 				analyzer = new LithuanianAnalyzer();
 				break;
 			case "lv":	
-				analyzer = new LatvianAnalyzer(LUCENE_VERSION);
+				analyzer = new LatvianAnalyzer();
 				break;
 			case "ro":	
-				analyzer = new RomanianAnalyzer(LUCENE_VERSION);
+				analyzer = new RomanianAnalyzer();
 				break;
 			case "sl":	
 				analyzer = new SlovenianAnalyzer();
@@ -230,7 +229,7 @@ public class LuceneIndexer extends LuceneInterface{
 			default:	
 				logger.warn("I cannot process the required language. "
 						+ "English used.");
-				analyzer = new StandardAnalyzer(LUCENE_VERSION);
+				analyzer = new StandardAnalyzer();
 		}
 		return analyzer;
 	}

--- a/src/main/java/cat/lump/ir/lucene/index/LuceneIndexerWT.java
+++ b/src/main/java/cat/lump/ir/lucene/index/LuceneIndexerWT.java
@@ -179,7 +179,6 @@ public class LuceneIndexerWT extends LuceneInterface{
     }
 
     IndexWriterConfig iwc = new IndexWriterConfig(
-        LUCENE_VERSION, 
         setAnalyzer(language)   //the analyser of the considered language
         );
     //We use the simple similarity model (tf-only)

--- a/src/main/java/cat/lump/ir/lucene/query/LuceneTokenizer.java
+++ b/src/main/java/cat/lump/ir/lucene/query/LuceneTokenizer.java
@@ -32,7 +32,6 @@ import org.apache.lucene.analysis.ru.RussianAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 
-import cat.lump.ir.lucene.LuceneInterface;
 import cat.lump.ir.lucene.index.analyzers.LithuanianAnalyzer;
 import cat.lump.aq.basics.log.LumpLogger;
 
@@ -70,52 +69,52 @@ public class LuceneTokenizer {
 	protected void setAnalyzer(Locale lan){
 		switch(lan.getLanguage()){
 			case "ar":
-				analyzer = new ArabicAnalyzer(LuceneInterface.LUCENE_VERSION);
+				analyzer = new ArabicAnalyzer();
 				break;
 			case "bg":
-				analyzer = new BulgarianAnalyzer(LuceneInterface.LUCENE_VERSION);
+				analyzer = new BulgarianAnalyzer();
 				break;
 			case "ca":
-				analyzer = new CatalanAnalyzer(LuceneInterface.LUCENE_VERSION);
+				analyzer = new CatalanAnalyzer();
 				break;
 			case "cs":
-				analyzer = new CzechAnalyzer(LuceneInterface.LUCENE_VERSION);
+				analyzer = new CzechAnalyzer();
 				break;
 			case "de":
-				analyzer = new GermanAnalyzer(LuceneInterface.LUCENE_VERSION);
+				analyzer = new GermanAnalyzer();
 				break;
 			case "el":
-				analyzer = new GreekAnalyzer(LuceneInterface.LUCENE_VERSION);
+				analyzer = new GreekAnalyzer();
 				break;
 			case "en":
-				analyzer = new StandardAnalyzer(LuceneInterface.LUCENE_VERSION);
+				analyzer = new StandardAnalyzer();
 				break;
 			case "es":
-				analyzer = new SpanishAnalyzer(LuceneInterface.LUCENE_VERSION);
+				analyzer = new SpanishAnalyzer();
 				break;
 			case "eu":
-				analyzer = new BasqueAnalyzer(LuceneInterface.LUCENE_VERSION);
+				analyzer = new BasqueAnalyzer();
 				break;
 			case "fr":
-				analyzer = new FrenchAnalyzer(LuceneInterface.LUCENE_VERSION);
+				analyzer = new FrenchAnalyzer();
 				break;
 			case "hu":
-				analyzer = new HungarianAnalyzer(LuceneInterface.LUCENE_VERSION);
+				analyzer = new HungarianAnalyzer();
 				break;
 			case "it":
-				analyzer = new ItalianAnalyzer(LuceneInterface.LUCENE_VERSION);
+				analyzer = new ItalianAnalyzer();
 				break;
 			case "lt":
 				analyzer = new LithuanianAnalyzer();
 				break;	
 			case "pt":
-				analyzer = new PortugueseAnalyzer(LuceneInterface.LUCENE_VERSION);
+				analyzer = new PortugueseAnalyzer();
 				break;
 			case "ro":
-				analyzer = new RomanianAnalyzer(LuceneInterface.LUCENE_VERSION);
+				analyzer = new RomanianAnalyzer();
 				break;
 			case "ru":
-				analyzer = new RussianAnalyzer(LuceneInterface.LUCENE_VERSION);
+				analyzer = new RussianAnalyzer();
 				break;
 			default:
 				log.warn("I cannot process the required language.");


### PR DESCRIPTION
In previous versions, it was necessary to explicitly state the version of Lucene when indexing and querying. Currently, all those calls (e.g., VERSION.7_0_0) are deprecated. 

https://lucene.apache.org/core/8_3_0/core/index.html

The only non-deprecated version is VERSION.LATEST. Nevertheless, the documentation discourages it's use, as LATEST will change upon update of the dependency. 

In any case, the invocation to indexing, querying, etc. does not require the version as a parameter any more, and hence it can be discarded. 